### PR TITLE
Fix RDS decoder information flag mapping

### DIFF
--- a/cfg/pdx.yml
+++ b/cfg/pdx.yml
@@ -9,10 +9,10 @@ rds:
   ta: false
   ms_music: true
   di:
-    stereo: false # actually dynamic_pty
-    artificial_head: true # actually compressed
-    compressed: false # actually articial_head
-    dynamic_pty: true # actually is has_stereo
+    stereo: false
+    artificial_head: true
+    compressed: false
+    dynamic_pty: true
   ps:
     - "RADIO"
     - "PLOFKIP"

--- a/si4713/__init__.py
+++ b/si4713/__init__.py
@@ -216,17 +216,17 @@ class SI4713:
         compressed: Optional[bool] = None,
         dynamic_pty: Optional[bool] = None,
     ) -> None:
-        if stereo is not None:
-            self.misc = (self.misc | (1 << 12)) if stereo else (
-                self.misc & ~(1 << 12))
-        if artificial_head is not None:
-            self.misc = (self.misc | (1 << 13)) if artificial_head else (
-                self.misc & ~(1 << 13))
-        if compressed is not None:
-            self.misc = (self.misc | (1 << 14)) if compressed else (
-                self.misc & ~(1 << 14))
         if dynamic_pty is not None:
-            self.misc = (self.misc | (1 << 15)) if dynamic_pty else (
+            self.misc = (self.misc | (1 << 12)) if dynamic_pty else (
+                self.misc & ~(1 << 12))
+        if compressed is not None:
+            self.misc = (self.misc | (1 << 13)) if compressed else (
+                self.misc & ~(1 << 13))
+        if artificial_head is not None:
+            self.misc = (self.misc | (1 << 14)) if artificial_head else (
+                self.misc & ~(1 << 14))
+        if stereo is not None:
+            self.misc = (self.misc | (1 << 15)) if stereo else (
                 self.misc & ~(1 << 15))
         self._set_prop(0x2C03, self.misc)
 


### PR DESCRIPTION
## Summary
- correct SI4713 RDS decoder information bit mapping for stereo, artificial head, compressed, and dynamic PTY
- update sample config to reflect fixed flag mapping

## Testing
- `python -m py_compile si4713/__init__.py picast4713.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66a643cb0832fb5ea23f2bd20e434