### PR TITLE
Restore last broadcast session and modernize dashboard layout

### DIFF
--- a/docs/datasheet-notes.md
+++ b/docs/datasheet-notes.md
@@ -1,0 +1,7 @@
+# Si4712/13-B30 Datasheet Excerpts
+
+> Production test conditions: VDD = 3.3 V, VIO = 3.3 V, TA = 25 °C, FRF = 98 MHz. Characterization test conditions: VDD = 2.7 to 5.5 V, VIO = 1.5 to 3.6 V, TA = –20 to 85 °C, FRF = 76–108 MHz. Transmit Frequency Range fRF 76 — 108 MHz.
+
+> The Si4712/13-B30 integrates the complete transmit functions for standards-compliant unlicensed FM broadcast stereo transmission. The chip also allows integrated receive power scanning to identify low signal power FM channels. Users must comply with local regulations on radio frequency (RF) transmission.
+
+These excerpts were reviewed while validating the startup behaviour and frequency presentation changes in the dashboard.

--- a/tests/test_transmitter_manager.py
+++ b/tests/test_transmitter_manager.py
@@ -382,10 +382,11 @@ def test_toggle_broadcast_cycle(manager: TransmitterManager, tmp_path: Path) -> 
 
     status = manager.set_broadcast(False)
     assert status["broadcasting"] is False
-    assert status["watchdog_status"] == "paused"
+    assert status["watchdog_status"] == "stopped"
     assert status["rds"]["enabled"] is False
     assert status["audio_input_dbfs"] is None
     assert status["audio"]["limiter_on"] is True
+    assert manager._tx is None  # type: ignore[attr-defined]
 
     status = manager.set_broadcast(True)
     assert status["broadcasting"] is True

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -31,6 +31,11 @@ def create_app(config: dict[str, Any] | None = None) -> "Flask":
     app.transmitter_manager = manager  # type: ignore[attr-defined]
     app.register_blueprint(bp)
 
+    try:
+        manager.restore_last_session()
+    except Exception:  # noqa: BLE001
+        LOGGER.exception("Failed to restore last transmitter session")
+
     def _stop_manager() -> None:
         try:
             manager.shutdown()

--- a/webapp/static/css/main.css
+++ b/webapp/static/css/main.css
@@ -57,6 +57,66 @@ body {
   gap: 2rem;
 }
 
+.tab-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 999px;
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  width: fit-content;
+}
+
+.tab-nav__link {
+  border: none;
+  background: transparent;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-nav__link:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tab-nav__link:hover {
+  color: var(--text);
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.tab-nav__link.is-active {
+  background: var(--surface);
+  color: var(--accent);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.18);
+}
+
+.tab-panel[hidden] {
+  display: none;
+}
+
+.tab-panel.is-active {
+  animation: tabFade 0.24s ease;
+}
+
+@keyframes tabFade {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .card {
   background: var(--surface);
   border-radius: var(--card-radius);

--- a/webapp/static/css/main.css
+++ b/webapp/static/css/main.css
@@ -425,6 +425,83 @@ body {
   gap: 0.75rem;
 }
 
+.card__section--bordered {
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.card--form .card__title {
+  font-size: 1.1rem;
+}
+
+.section-title {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.form-grid--three {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.form-grid--four {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field--span-2 {
+  grid-column: 1 / -1;
+}
+
+.form-options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.form-options--two {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.form-checkbox {
+  background: var(--surface-muted);
+  border-radius: 10px;
+  border: 1px solid transparent;
+  padding: 0.65rem 0.75rem;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.form-checkbox:hover {
+  background: #e2e8f0;
+  border-color: var(--border);
+}
+
+.form-checkbox--inline {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.form-checkbox--inline:hover {
+  background: transparent;
+  border: none;
+}
+
 .preset-row {
   display: flex;
   flex-wrap: wrap;

--- a/webapp/static/js/main.js
+++ b/webapp/static/js/main.js
@@ -89,8 +89,34 @@ let formEnabled = false;
 let suspendDirty = false;
 
 function formatFrequency(khz) {
-  if (!khz) return '—';
-  return `${(khz / 1000).toFixed(3)} MHz`;
+  const numeric = Number(khz);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return '—';
+  }
+  return `${(numeric / 1000).toFixed(2)} MHz`;
+}
+
+function fromKhzToMHz(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return '';
+  }
+  return (numeric / 1000).toFixed(2);
+}
+
+function toKhzFromMHz(raw) {
+  if (raw === null || raw === undefined) {
+    return '';
+  }
+  const trimmed = String(raw).trim();
+  if (!trimmed) {
+    return '';
+  }
+  const numeric = Number(trimmed);
+  if (!Number.isFinite(numeric)) {
+    return trimmed;
+  }
+  return Math.round(numeric * 1000).toString();
 }
 
 function sanitizePiDigits(raw) {
@@ -569,7 +595,9 @@ function showFeedback(message, type = 'success') {
 
 function populateForm(config) {
   suspendDirty = true;
-  document.getElementById('rf-frequency').value = config.rf?.frequency_khz ?? '';
+  document.getElementById('rf-frequency').value = fromKhzToMHz(
+    config.rf?.frequency_khz
+  );
   document.getElementById('rf-power').value = config.rf?.power ?? '';
   document.getElementById('rf-antenna').value = config.rf?.antenna_cap ?? '';
 
@@ -632,7 +660,7 @@ function populateForm(config) {
 function collectFormData() {
   return {
     rf: {
-      frequency_khz: document.getElementById('rf-frequency').value.trim(),
+      frequency_khz: toKhzFromMHz(document.getElementById('rf-frequency').value),
       power: document.getElementById('rf-power').value.trim(),
       antenna_cap: document.getElementById('rf-antenna').value.trim(),
     },

--- a/webapp/static/js/main.js
+++ b/webapp/static/js/main.js
@@ -32,6 +32,9 @@ const piInput = document.getElementById('rds-pi');
 const audioPresetSelect = document.getElementById('audio-preset');
 const audioPresetReset = document.getElementById('audio-preset-reset');
 
+const tabButtons = Array.from(document.querySelectorAll('.tab-nav__link'));
+const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+
 const AUDIO_PRESETS = {
   broadcast: {
     label: 'Broadcast reference (–16 dBFS)',
@@ -87,6 +90,45 @@ let currentConfig = '';
 let isDirty = false;
 let formEnabled = false;
 let suspendDirty = false;
+
+function activateTab(name) {
+  if (!name) {
+    return;
+  }
+
+  tabButtons.forEach((button) => {
+    const isActive = button.dataset.tab === name;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-selected', String(isActive));
+  });
+
+  tabPanels.forEach((panel) => {
+    const isActive = panel.dataset.tabPanel === name;
+    panel.classList.toggle('is-active', isActive);
+    panel.toggleAttribute('hidden', !isActive);
+  });
+}
+
+tabButtons.forEach((button, index) => {
+  button.addEventListener('click', () => {
+    activateTab(button.dataset.tab);
+  });
+
+  button.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+      return;
+    }
+
+    event.preventDefault();
+    const offset = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (index + offset + tabButtons.length) % tabButtons.length;
+    const nextButton = tabButtons[nextIndex];
+    nextButton.focus();
+    activateTab(nextButton.dataset.tab);
+  });
+});
+
+activateTab('overview');
 
 function formatFrequency(khz) {
   const numeric = Number(khz);

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -139,229 +139,259 @@
 
         <fieldset id="config-fields" class="config-fieldset" disabled>
           <div class="pure-g config-grid">
-          <div class="pure-u-1 pure-u-lg-1-3 config-column">
-            <section class="card card--compact">
-              <header class="card__header">
-                <h3 class="card__title">RF Settings</h3>
-              </header>
-              <div class="card__body card__body--compact">
-                <label for="rf-frequency">Frequency (kHz)</label>
-                <input type="number" id="rf-frequency" class="pure-input-1" min="76000" step="1">
-                <label for="rf-power">Power (dBµV)</label>
-                <input type="number" id="rf-power" class="pure-input-1" min="88" max="120">
-                <label for="rf-antenna">Antenna Capacitance</label>
-                <input type="number" id="rf-antenna" class="pure-input-1" min="0" max="255">
-              </div>
-            </section>
-
-            <section class="card card--compact">
-              <header class="card__header">
-                <h3 class="card__title">Audio Processing</h3>
-              </header>
-              <div class="card__body card__body--compact">
-                <div class="card__section">
-                  <label for="audio-preset" class="form-label">Limiter Preset</label>
-                  <div class="preset-row">
-                    <select id="audio-preset" class="pure-input-1">
-                      <option value="">Select preset…</option>
-                      <option value="broadcast">Broadcast reference (–16 dBFS)</option>
-                      <option value="music">Music – Smooth</option>
-                      <option value="voice">Speech – Articulate</option>
-                    </select>
-                    <button type="button" class="pure-button pure-button-secondary" id="audio-preset-reset">
-                      Reset to preset
-                    </button>
-                  </div>
-                  <span class="input-hint">Presets follow the Silicon Labs limiter guidance; use them to recover from clipping.</span>
-                </div>
-                <label class="checkbox">
-                  <input type="checkbox" id="audio-agc">
-                  <span>Automatic Gain Control (AGC)</span>
-                </label>
-                <label class="checkbox">
-                  <input type="checkbox" id="audio-limiter">
-                  <span>Limiter Enabled</span>
-                </label>
-                <label for="audio-comp-thr">Compressor Threshold (dB)</label>
-                <input type="number" id="audio-comp-thr" class="pure-input-1" min="-96" max="31">
-                <label for="audio-comp-att">Attack (index)</label>
-                <input type="number" id="audio-comp-att" class="pure-input-1" min="0" max="63">
-                <label for="audio-comp-rel">Release (index)</label>
-                <input type="number" id="audio-comp-rel" class="pure-input-1" min="0" max="63">
-                <label for="audio-comp-gain">Gain (dB)</label>
-                <input type="number" id="audio-comp-gain" class="pure-input-1" min="0" max="63">
-                <label for="audio-lim-rel">Limiter Release (index)</label>
-                <input type="number" id="audio-lim-rel" class="pure-input-1" min="0" max="1023">
-              </div>
-            </section>
-
-            <section class="card card--compact">
-              <header class="card__header">
-                <h3 class="card__title">Watchdog &amp; Monitoring</h3>
-              </header>
+            <div class="pure-u-1 pure-u-lg-1-3 config-column">
+              <section class="card card--form">
+                <header class="card__header">
+                  <h3 class="card__title">RF &amp; Monitoring</h3>
+                </header>
                 <div class="card__body card__body--compact">
-                  <label class="checkbox">
-                    <input type="checkbox" id="monitor-health">
-                    <span>Hardware Health</span>
-                  </label>
-                  <label class="checkbox">
-                    <input type="checkbox" id="monitor-asq">
-                    <span>ASQ Monitoring</span>
-                  </label>
-                  <label for="monitor-interval">Interval (s)</label>
-                  <input type="number" id="monitor-interval" class="pure-input-1" min="0.1" step="0.1">
-                  <label for="monitor-recovery-attempts">Recovery Attempts</label>
-                  <input type="number" id="monitor-recovery-attempts" class="pure-input-1" min="0">
-                  <label for="monitor-recovery-backoff">Recovery Backoff (s)</label>
-                  <input type="number" id="monitor-recovery-backoff" class="pure-input-1" min="0" step="0.1">
+                  <div class="card__section">
+                    <h4 class="section-title">Carrier</h4>
+                    <div class="form-grid form-grid--two">
+                      <div class="form-field">
+                        <label for="rf-frequency">Frequency (MHz)</label>
+                        <input type="number" id="rf-frequency" class="pure-input-1" min="76" max="108" step="0.01" inputmode="decimal">
+                      </div>
+                      <div class="form-field">
+                        <label for="rf-power">Power (dBµV)</label>
+                        <input type="number" id="rf-power" class="pure-input-1" min="88" max="120">
+                      </div>
+                      <div class="form-field">
+                        <label for="rf-antenna">Antenna Capacitance</label>
+                        <input type="number" id="rf-antenna" class="pure-input-1" min="0" max="255">
+                      </div>
+                    </div>
+                  </div>
+                  <div class="card__section card__section--bordered">
+                    <h4 class="section-title">Watchdog</h4>
+                    <div class="form-options form-options--two">
+                      <label class="checkbox form-checkbox">
+                        <input type="checkbox" id="monitor-health">
+                        <span>Hardware Health</span>
+                      </label>
+                      <label class="checkbox form-checkbox">
+                        <input type="checkbox" id="monitor-asq">
+                        <span>ASQ Monitoring</span>
+                      </label>
+                    </div>
+                    <div class="form-grid form-grid--three">
+                      <div class="form-field">
+                        <label for="monitor-interval">Interval (s)</label>
+                        <input type="number" id="monitor-interval" class="pure-input-1" min="0.1" step="0.1">
+                      </div>
+                      <div class="form-field">
+                        <label for="monitor-recovery-attempts">Recovery Attempts</label>
+                        <input type="number" id="monitor-recovery-attempts" class="pure-input-1" min="0">
+                      </div>
+                      <div class="form-field">
+                        <label for="monitor-recovery-backoff">Recovery Backoff (s)</label>
+                        <input type="number" id="monitor-recovery-backoff" class="pure-input-1" min="0" step="0.1">
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <section class="card card--form">
+                <header class="card__header">
+                  <h3 class="card__title">Audio Processing</h3>
+                </header>
+                <div class="card__body card__body--compact">
+                  <div class="card__section">
+                    <h4 class="section-title">Limiter Presets</h4>
+                    <div class="preset-row">
+                      <select id="audio-preset" class="pure-input-1">
+                        <option value="">Select preset…</option>
+                        <option value="broadcast">Broadcast reference (–16 dBFS)</option>
+                        <option value="music">Music – Smooth</option>
+                        <option value="voice">Speech – Articulate</option>
+                      </select>
+                      <button type="button" class="pure-button pure-button-secondary" id="audio-preset-reset">
+                        Reset to preset
+                      </button>
+                    </div>
+                    <span class="input-hint">Presets follow the Silicon Labs limiter guidance; use them to recover from clipping.</span>
+                  </div>
+                  <div class="form-options form-options--two">
+                    <label class="checkbox form-checkbox">
+                      <input type="checkbox" id="audio-agc">
+                      <span>Automatic Gain Control (AGC)</span>
+                    </label>
+                    <label class="checkbox form-checkbox">
+                      <input type="checkbox" id="audio-limiter">
+                      <span>Limiter Enabled</span>
+                    </label>
+                  </div>
+                  <div class="form-grid form-grid--three">
+                    <div class="form-field">
+                      <label for="audio-comp-thr">Compressor Threshold (dB)</label>
+                      <input type="number" id="audio-comp-thr" class="pure-input-1" min="-96" max="31">
+                    </div>
+                    <div class="form-field">
+                      <label for="audio-comp-att">Attack (index)</label>
+                      <input type="number" id="audio-comp-att" class="pure-input-1" min="0" max="63">
+                    </div>
+                    <div class="form-field">
+                      <label for="audio-comp-rel">Release (index)</label>
+                      <input type="number" id="audio-comp-rel" class="pure-input-1" min="0" max="63">
+                    </div>
+                    <div class="form-field">
+                      <label for="audio-comp-gain">Gain (dB)</label>
+                      <input type="number" id="audio-comp-gain" class="pure-input-1" min="0" max="63">
+                    </div>
+                    <div class="form-field">
+                      <label for="audio-lim-rel">Limiter Release (index)</label>
+                      <input type="number" id="audio-lim-rel" class="pure-input-1" min="0" max="1023">
+                    </div>
+                  </div>
                 </div>
               </section>
             </div>
 
             <div class="pure-u-1 pure-u-lg-2-3 config-column">
-              <section class="card card--compact">
+              <section class="card card--form">
                 <header class="card__header">
-                  <h3 class="card__title">RDS Identity</h3>
+                  <h3 class="card__title">RDS Identity &amp; Flags</h3>
                 </header>
-                <div class="card__body card__body--compact rds-grid">
-                  <div>
-                    <label for="rds-pi">PI Code</label>
-                    <div class="input-prefix">
-                      <span>0x</span>
-                      <input
-                        type="text"
-                        id="rds-pi"
-                        class="pure-input-1 text-uppercase"
-                        placeholder="1EE7"
-                        pattern="[0-9A-Fa-f]*"
-                        inputmode="text"
-                        maxlength="4"
-                        autocomplete="off"
-                      >
+                <div class="card__body card__body--compact">
+                  <div class="card__section">
+                    <h4 class="section-title">Core Identity</h4>
+                    <div class="form-grid form-grid--three">
+                      <div class="form-field">
+                        <label for="rds-pi">PI Code</label>
+                        <div class="input-prefix">
+                          <span>0x</span>
+                          <input
+                            type="text"
+                            id="rds-pi"
+                            class="pure-input-1 text-uppercase"
+                            placeholder="1EE7"
+                            pattern="[0-9A-Fa-f]*"
+                            inputmode="text"
+                            maxlength="4"
+                            autocomplete="off"
+                          >
+                        </div>
+                        <span class="input-hint">Enter a 16-bit hexadecimal value.</span>
+                      </div>
+                      <div class="form-field">
+                        <label for="rds-pty">PTY</label>
+                        <input type="number" id="rds-pty" class="pure-input-1" min="0" max="31">
+                      </div>
+                      <div class="form-field">
+                        <label for="rds-deviation">RDS Deviation (10 Hz)</label>
+                        <input type="number" id="rds-deviation" class="pure-input-1" min="0">
+                      </div>
                     </div>
-                    <span class="input-hint">Enter a 16-bit hexadecimal value.</span>
                   </div>
-                  <div>
-                    <label for="rds-pty">PTY</label>
-                    <input type="number" id="rds-pty" class="pure-input-1" min="0" max="31">
-                  </div>
-                  <div>
-                    <label for="rds-deviation">RDS Deviation (10 Hz)</label>
-                    <input type="number" id="rds-deviation" class="pure-input-1" min="0">
-                  </div>
-                </div>
-              </section>
-
-              <section class="card card--compact">
-                <header class="card__header">
-                  <h3 class="card__title">RDS Flags</h3>
-                </header>
-                <div class="card__body card__body--compact rds-grid">
-                  {% for field_id, label in rds_flag_switches %}
-                    <label class="checkbox">
-                      <input type="checkbox" id="{{ field_id }}">
-                      <span>{{ label }}</span>
-                    </label>
-                  {% endfor %}
-                  <div class="di-group">
-                    <span class="input-hint">Decoder Identification (DI)</span>
-                    <div class="chip-row chip-row--inputs">
-                      {% for field_id, label in di_flags %}
-                        <label class="checkbox checkbox--inline">
+                  <div class="card__section card__section--bordered">
+                    <h4 class="section-title">Programme Flags</h4>
+                    <div class="form-options form-options--two">
+                      {% for field_id, label in rds_flag_switches %}
+                        <label class="checkbox form-checkbox">
                           <input type="checkbox" id="{{ field_id }}">
                           <span>{{ label }}</span>
                         </label>
                       {% endfor %}
                     </div>
+                    <div class="di-group">
+                      <span class="input-hint">Decoder Identification (DI)</span>
+                      <div class="chip-row chip-row--inputs">
+                        {% for field_id, label in di_flags %}
+                          <label class="checkbox checkbox--inline">
+                            <input type="checkbox" id="{{ field_id }}">
+                            <span>{{ label }}</span>
+                          </label>
+                        {% endfor %}
+                      </div>
+                    </div>
                   </div>
                 </div>
               </section>
 
-              <section class="card card--compact">
+              <section class="card card--form">
                 <header class="card__header">
-                  <h3 class="card__title">Program Service (PS)</h3>
+                  <h3 class="card__title">Programme Content</h3>
                 </header>
                 <div class="card__body card__body--compact">
                   <div class="card__section">
+                    <h4 class="section-title">Program Service (PS)</h4>
                     <div class="section-header">
                       <label class="form-label" for="ps-list">PS Slots</label>
                       <button type="button" class="pure-button pure-button-secondary" id="btn-add-ps">Add Slot</button>
                     </div>
                     <div id="ps-list" class="stack"></div>
+                    <div class="form-grid form-grid--three">
+                      <div class="form-field">
+                        <label for="rds-ps-count">Active Slots</label>
+                        <input type="number" id="rds-ps-count" class="pure-input-1" min="1" max="8">
+                      </div>
+                      <div class="form-field">
+                        <label for="rds-ps-speed">Cycle Speed (s)</label>
+                        <input type="number" id="rds-ps-speed" class="pure-input-1" min="1">
+                      </div>
+                      <label class="checkbox form-checkbox form-checkbox--inline">
+                        <input type="checkbox" id="rds-ps-center">
+                        <span>Center text</span>
+                      </label>
+                    </div>
                   </div>
-                  <div class="rds-grid">
-                    <div>
-                      <label for="rds-ps-count">Active Slots</label>
-                      <input type="number" id="rds-ps-count" class="pure-input-1" min="1" max="8">
+                  <div class="card__section card__section--bordered">
+                    <h4 class="section-title">Radiotext (RT)</h4>
+                    <div class="form-grid form-grid--two">
+                      <div class="form-field form-field--span-2">
+                        <label for="rt-text">Fallback Text</label>
+                        <input type="text" id="rt-text" class="pure-input-1" maxlength="64">
+                      </div>
+                      <div class="form-field">
+                        <label for="rt-speed">Rotation Speed (s)</label>
+                        <input type="number" id="rt-speed" class="pure-input-1" min="1" step="0.1">
+                      </div>
+                      <label class="checkbox form-checkbox form-checkbox--inline">
+                        <input type="checkbox" id="rt-center">
+                        <span>Center text</span>
+                      </label>
                     </div>
-                    <div>
-                      <label for="rds-ps-speed">Cycle Speed</label>
-                      <input type="number" id="rds-ps-speed" class="pure-input-1" min="1">
+                    <div class="card__section">
+                      <div class="section-header">
+                        <label class="form-label" for="rt-texts-list">Rotation Entries</label>
+                        <button type="button" class="pure-button pure-button-secondary" id="btn-add-rt-text">Add Entry</button>
+                      </div>
+                      <div id="rt-texts-list" class="stack"></div>
                     </div>
-                    <label class="checkbox">
-                      <input type="checkbox" id="rds-ps-center">
-                      <span>Center text</span>
-                    </label>
-                  </div>
-                </div>
-              </section>
-
-              <section class="card card--compact">
-                <header class="card__header">
-                  <h3 class="card__title">Radiotext (RT)</h3>
-                </header>
-                <div class="card__body card__body--compact">
-                  <div class="rds-grid">
-                    <div>
-                      <label for="rt-text">Fallback Text</label>
-                      <input type="text" id="rt-text" class="pure-input-1" maxlength="64">
+                    <div class="form-field form-field--span-2">
+                      <label for="rt-file-path">External Script File</label>
+                      <input type="text" id="rt-file-path" class="pure-input-1" placeholder="/path/to/rt.txt">
+                      <span class="input-hint">Leave blank to disable file sourcing.</span>
                     </div>
-                    <div>
-                      <label for="rt-speed">Rotation Speed (s)</label>
-                      <input type="number" id="rt-speed" class="pure-input-1" min="1" step="0.1">
+                    <div class="card__section">
+                      <div class="section-header">
+                        <label class="form-label" for="rt-skip-words-list">Skip Words</label>
+                        <button type="button" class="pure-button pure-button-secondary" id="btn-add-skip-word">Add Word</button>
+                      </div>
+                      <div id="rt-skip-words-list" class="stack"></div>
                     </div>
-                    <label class="checkbox">
-                      <input type="checkbox" id="rt-center">
-                      <span>Center text</span>
-                    </label>
-                  </div>
-                  <div class="card__section">
-                    <div class="section-header">
-                      <label class="form-label" for="rt-texts-list">Rotation Entries</label>
-                      <button type="button" class="pure-button pure-button-secondary" id="btn-add-rt-text">Add Entry</button>
-                    </div>
-                    <div id="rt-texts-list" class="stack"></div>
-                  </div>
-                  <label for="rt-file-path">External Script File</label>
-                  <input type="text" id="rt-file-path" class="pure-input-1" placeholder="/path/to/rt.txt">
-                  <span class="input-hint">Leave blank to disable file sourcing.</span>
-                  <div class="card__section">
-                    <div class="section-header">
-                      <label class="form-label" for="rt-skip-words-list">Skip Words</label>
-                      <button type="button" class="pure-button pure-button-secondary" id="btn-add-skip-word">Add Word</button>
-                    </div>
-                    <div id="rt-skip-words-list" class="stack"></div>
-                  </div>
-                  <div class="rds-grid">
-                    <div>
-                      <label for="rt-ab-mode">A/B Mode</label>
-                      <select id="rt-ab-mode" class="pure-input-1">
-                        <option value="auto">Auto</option>
-                        <option value="legacy">Legacy</option>
-                        <option value="bank">Bank</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label for="rt-repeats">Burst Repeats</label>
-                      <input type="number" id="rt-repeats" class="pure-input-1" min="1">
-                    </div>
-                    <div>
-                      <label for="rt-gap">Burst Gap (ms)</label>
-                      <input type="number" id="rt-gap" class="pure-input-1" min="0">
-                    </div>
-                    <div>
-                      <label for="rt-bank">Bank (0/1)</label>
-                      <input type="number" id="rt-bank" class="pure-input-1" min="0" max="1">
+                    <div class="form-grid form-grid--four">
+                      <div class="form-field">
+                        <label for="rt-ab-mode">A/B Mode</label>
+                        <select id="rt-ab-mode" class="pure-input-1">
+                          <option value="auto">Auto</option>
+                          <option value="legacy">Legacy</option>
+                          <option value="bank">Bank</option>
+                        </select>
+                      </div>
+                      <div class="form-field">
+                        <label for="rt-repeats">Burst Repeats</label>
+                        <input type="number" id="rt-repeats" class="pure-input-1" min="1">
+                      </div>
+                      <div class="form-field">
+                        <label for="rt-gap">Burst Gap (ms)</label>
+                        <input type="number" id="rt-gap" class="pure-input-1" min="0">
+                      </div>
+                      <div class="form-field">
+                        <label for="rt-bank">Bank (0/1)</label>
+                        <input type="number" id="rt-bank" class="pure-input-1" min="0" max="1">
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -14,6 +14,11 @@
       <div class="app-bar__subtitle">Responsive FM + RDS control surface</div>
     </header>
     <main class="page">
+      <nav class="tab-nav" role="tablist" aria-label="Dashboard sections">
+        <button type="button" class="tab-nav__link is-active" id="tab-button-overview" role="tab" aria-selected="true" data-tab="overview" aria-controls="tab-overview">Overview</button>
+        <button type="button" class="tab-nav__link" id="tab-button-profiles" role="tab" aria-selected="false" data-tab="profiles" aria-controls="tab-profiles">Profiles</button>
+        <button type="button" class="tab-nav__link" id="tab-button-configuration" role="tab" aria-selected="false" data-tab="configuration" aria-controls="tab-configuration">Configuration</button>
+      </nav>
       {% set di_flags = [
         ("di-stereo", "Stereo"),
         ("di-artificial-head", "Artificial Head"),
@@ -26,7 +31,7 @@
         ("rds-ms-music", "Music Service")
       ] %}
 
-      <section class="card card--hero">
+      <section class="card card--hero tab-panel is-active" data-tab-panel="overview" id="tab-overview" role="tabpanel" aria-labelledby="tab-button-overview">
         <header class="card__header">
           <div>
             <h1 class="card__title">Live Broadcast Snapshot</h1>
@@ -110,34 +115,37 @@
       </section>
 
       <form id="config-form" class="pure-form pure-form-stacked">
-        <section class="card card--profiles">
-          <header class="card__header">
-            <div>
-              <h2 class="card__title">Configuration Profiles</h2>
-              <p class="card__subtitle">Load, edit, and save transmitter profiles</p>
+        <div class="tab-panel" data-tab-panel="profiles" id="tab-profiles" role="tabpanel" aria-labelledby="tab-button-profiles" hidden>
+          <section class="card card--profiles">
+            <header class="card__header">
+              <div>
+                <h2 class="card__title">Configuration Profiles</h2>
+                <p class="card__subtitle">Load, edit, and save transmitter profiles</p>
+              </div>
+            </header>
+            <div class="card__body">
+              <label for="config-select" class="form-label">Available Profiles</label>
+              <div class="input-row">
+                <select id="config-select" class="pure-input-1">
+                  <option value="">Select configuration…</option>
+                  {% for item in configs %}
+                    <option value="{{ item }}">{{ item }}</option>
+                  {% endfor %}
+                </select>
+                <button class="pure-button" id="btn-refresh" type="button">Refresh</button>
+              </div>
+              <div class="button-row">
+                <button class="pure-button" id="btn-duplicate" type="button" disabled>Duplicate</button>
+                <div class="button-row__spacer"></div>
+                <button class="pure-button" id="btn-save" type="button" disabled>Save</button>
+                <button class="pure-button pure-button-primary" id="btn-apply" type="button" disabled>Apply &amp; Activate</button>
+              </div>
             </div>
-          </header>
-          <div class="card__body">
-            <label for="config-select" class="form-label">Available Profiles</label>
-            <div class="input-row">
-              <select id="config-select" class="pure-input-1">
-                <option value="">Select configuration…</option>
-                {% for item in configs %}
-                  <option value="{{ item }}">{{ item }}</option>
-                {% endfor %}
-              </select>
-              <button class="pure-button" id="btn-refresh" type="button">Refresh</button>
-            </div>
-            <div class="button-row">
-              <button class="pure-button" id="btn-duplicate" type="button" disabled>Duplicate</button>
-              <div class="button-row__spacer"></div>
-              <button class="pure-button" id="btn-save" type="button" disabled>Save</button>
-              <button class="pure-button pure-button-primary" id="btn-apply" type="button" disabled>Apply &amp; Activate</button>
-            </div>
-          </div>
-        </section>
+          </section>
+        </div>
 
-        <fieldset id="config-fields" class="config-fieldset" disabled>
+        <div class="tab-panel" data-tab-panel="configuration" id="tab-configuration" role="tabpanel" aria-labelledby="tab-button-configuration" hidden>
+          <fieldset id="config-fields" class="config-fieldset" disabled>
           <div class="pure-g config-grid">
             <div class="pure-u-1 pure-u-lg-1-3 config-column">
               <section class="card card--form">
@@ -398,7 +406,8 @@
               </section>
             </div>
           </div>
-        </fieldset>
+          </fieldset>
+        </div>
       </form>
 
       <div class="notice notice--inline is-hidden" role="alert" id="config-feedback"></div>

--- a/webapp/transmitter.py
+++ b/webapp/transmitter.py
@@ -172,6 +172,7 @@ class TransmitterManager:
         self._metrics = Metrics()
         self._publisher = MetricsPublisher()
         self._watchdog_thread: Optional[threading.Thread] = None
+        self._config_applied = False
         self._state_path = self.config_root / ".session-state.json"
         self._session_state = {
             "last_profile": None,
@@ -576,6 +577,13 @@ class TransmitterManager:
                 if not cfg or self._config_path is None:
                     raise ValidationError("Apply a configuration before enabling broadcast")
                 tx = self._ensure_tx()
+                if not self._config_applied:
+                    try:
+                        LOGGER.info("Reapplying configuration before enabling broadcast")
+                        self._apply_config_on_backend(tx, cfg)
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.exception("Failed to reapply configuration")
+                        raise ValidationError(str(exc)) from exc
             else:
                 tx = self._tx
                 if tx is None:
@@ -594,6 +602,8 @@ class TransmitterManager:
                 self._audio_overmod = False
                 self._status_overmod = False
                 self._metrics.audio_input_dbfs = None
+                if not enabled:
+                    self._teardown_tx()
             if cfg:
                 if enabled and cfg.monitor_health:
                     try:
@@ -635,7 +645,7 @@ class TransmitterManager:
                 self._update_metrics(cfg, self._broadcasting)
             else:
                 self._metrics.broadcasting = enabled
-                self._metrics.watchdog_status = "running" if enabled else "paused"
+                self._metrics.watchdog_status = "running" if enabled else "stopped"
                 if not enabled:
                     self._metrics.audio_input_dbfs = None
                     self._metrics.audio = {}
@@ -661,16 +671,7 @@ class TransmitterManager:
             self._watchdog_thread.join(timeout=1)
         with self._lock:
             if self._tx is not None:
-                try:
-                    self._tx.hw_reset(RESET_PIN)
-                except Exception:  # noqa: BLE001
-                    LOGGER.exception("Failed to reset transmitter during shutdown")
-                finally:
-                    try:
-                        self._tx.close()
-                    except Exception:  # noqa: BLE001
-                        LOGGER.exception("Failed to close transmitter")
-                self._tx = None
+                self._teardown_tx()
 
     def restore_last_session(self) -> None:
         state = dict(self._session_state)
@@ -792,6 +793,7 @@ class TransmitterManager:
             raise ValidationError("SI4713 initialisation failed")
 
         self._tx = tx
+        self._config_applied = False
         return tx
 
     def _apply_config_on_backend(self, tx: Any, cfg: AppConfig) -> None:
@@ -799,6 +801,22 @@ class TransmitterManager:
             apply_tx_config(tx, cfg)
         )
         self._configure_ps_slots(cfg)
+        self._config_applied = True
+
+    def _teardown_tx(self) -> None:
+        tx = self._tx
+        if tx is None:
+            return
+        try:
+            tx.hw_reset(RESET_PIN)
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("Failed to reset transmitter during teardown")
+        try:
+            tx.close()
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("Failed to close transmitter during teardown")
+        self._tx = None
+        self._config_applied = False
 
     def _ensure_watchdog(self) -> None:
         if self._watchdog_thread and self._watchdog_thread.is_alive():
@@ -818,7 +836,7 @@ class TransmitterManager:
                 broadcast_since = self._broadcast_since
                 broadcasting = self._broadcasting
 
-                if not cfg or tx is None:
+                if not cfg:
                     self._metrics.watchdog_active = False
                     self._metrics.watchdog_status = "idle"
                     self._metrics.audio_input_dbfs = None
@@ -826,11 +844,20 @@ class TransmitterManager:
                     self._status_overmod = False
                     self._metrics.last_updated = time.time()
                     self._publisher.broadcast(self._metrics.to_dict())
+                elif tx is None:
+                    self._metrics.watchdog_active = False
+                    self._metrics.watchdog_status = "stopped"
+                    self._metrics.audio_input_dbfs = None
+                    self._metrics.audio = {}
+                    self._status_overmod = False
+                    self._metrics.broadcasting = False
+                    self._metrics.last_updated = time.time()
+                    self._publisher.broadcast(self._metrics.to_dict())
                 else:
                     interval = max(0.1, cfg.health_interval_s)
                     self._metrics.watchdog_active = True
                     self._metrics.watchdog_status = (
-                        "running" if broadcasting else "paused"
+                        "running" if broadcasting else "stopped"
                     )
 
                     overmod_flag = False
@@ -1051,7 +1078,7 @@ class TransmitterManager:
         self._metrics.antenna_cap = cfg.antenna_cap
         self._metrics.broadcasting = broadcasting
         self._metrics.watchdog_active = True
-        self._metrics.watchdog_status = "running" if broadcasting else "paused"
+        self._metrics.watchdog_status = "running" if broadcasting else "stopped"
         self._metrics.audio_input_dbfs = self._audio_level_dbfs
         self._metrics.audio = self._audio_snapshot(cfg)
         if broadcasting:


### PR DESCRIPTION
## Summary
- persist the last applied profile and broadcast state on disk so the dashboard auto-resumes transmission after restart
- polish the transmitter dashboard layout with reorganized cards, Pure.css grids, and MHz frequency inputs/display
- document datasheet excerpts consulted while validating startup and frequency requirements

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ea5ce38994832f98d5a7c5dde99916